### PR TITLE
Cleanup code

### DIFF
--- a/Asteroids.csproj
+++ b/Asteroids.csproj
@@ -1,5 +1,6 @@
 <Project Sdk="Godot.NET.Sdk/3.3.0">
   <PropertyGroup>
     <TargetFramework>net472</TargetFramework>
+    <LangVersion>10</LangVersion>
   </PropertyGroup>
 </Project>

--- a/Scripts/Audio/AudioEffect.cs
+++ b/Scripts/Audio/AudioEffect.cs
@@ -1,9 +1,12 @@
 using Godot;
 using System;
 
-public class AudioEffect : Tween
+namespace Asteroids.Scripts
 {
-    protected static int LowestVolume { get; } = -80;
+    public class AudioEffect : Tween
+    {
+        protected static int LowestVolume { get; } = -80;
 
-    protected static string VolumeProperty { get; } = "volume_db";
+        protected static string VolumeProperty { get; } = "volume_db";
+    }
 }

--- a/Scripts/Audio/AudioEffect.cs
+++ b/Scripts/Audio/AudioEffect.cs
@@ -1,6 +1,3 @@
-using Godot;
-using System;
-
 namespace Asteroids
 {
     public class AudioEffect : Tween

--- a/Scripts/Audio/AudioEffect.cs
+++ b/Scripts/Audio/AudioEffect.cs
@@ -1,7 +1,7 @@
 using Godot;
 using System;
 
-namespace Asteroids.Scripts
+namespace Asteroids
 {
     public class AudioEffect : Tween
     {

--- a/Scripts/Audio/AudioManager.cs
+++ b/Scripts/Audio/AudioManager.cs
@@ -1,7 +1,3 @@
-using Godot;
-using System;
-using Object = Godot.Object;
-
 namespace Asteroids
 {
     public class AudioManager : Node2D

--- a/Scripts/Audio/AudioManager.cs
+++ b/Scripts/Audio/AudioManager.cs
@@ -2,7 +2,7 @@ using Godot;
 using System;
 using Object = Godot.Object;
 
-namespace Asteroids.Scripts
+namespace Asteroids
 {
     public class AudioManager : Node2D
     {

--- a/Scripts/Audio/AudioManager.cs
+++ b/Scripts/Audio/AudioManager.cs
@@ -2,63 +2,66 @@ using Godot;
 using System;
 using Object = Godot.Object;
 
-public class AudioManager : Node2D
+namespace Asteroids.Scripts
 {
-
-    private const int MusicVolume = -15;
-    private const float FadeOutTransitionDuration = 3.0f;
-    private const float FadeInTransitionDuration = 2.0f;
-    
-    private AudioStreamPlayer _audioStreamPlayer;
-    private SpectrumAnalyzer _spectrumAnalyzer;
-
-    private FadeOutAudio _fadeOutAudio;
-    private FadeInAudio _fadeInAudio;
-    
-
-    // Called when the node enters the scene tree for the first time.
-    public override void _Ready()
+    public class AudioManager : Node2D
     {
-        _audioStreamPlayer = GetNode<AudioStreamPlayer>("Music_AudioStream");
-        _spectrumAnalyzer = GetNode<SpectrumAnalyzer>("/root/World/Spectrum_Analyzer");
-        _fadeOutAudio = GetNode<FadeOutAudio>("FadeOut_Tween");
-        _fadeInAudio = GetNode<FadeInAudio>("FadeIn_Tween");
-        
-        _spectrumAnalyzer.SetAudioStreamPlayer(_audioStreamPlayer);
-    }
-    
-    /*
-     * Play the audio stream player instantly
-     */
-    public void PlayAudioStreamPlayer()
-    {
-        _audioStreamPlayer.VolumeDb = MusicVolume;
-        _audioStreamPlayer.Play();
-    }
 
-    /*
-     * Stops the audio stream player instantly
-     */
-    public void StopAudioStreamPlayer()
-    {
-        _audioStreamPlayer.Stop();
-    }
-    
-    /*
-     * Plays a fade out effect to the audio stream player
-     * with the given transition duration
-     */
-    public void FadeOutAudio()
-    {
-        _fadeOutAudio.FadeOut(FadeOutTransitionDuration, _audioStreamPlayer);
-    }
+        private const int MusicVolume = -15;
+        private const float FadeOutTransitionDuration = 3.0f;
+        private const float FadeInTransitionDuration = 2.0f;
 
-    /*
-     * Plays a fade in effect to the audio stream player
-     * with the given transition duration
-     */
-    public void FadeInAudio()
-    {
-        _fadeInAudio.FadeIn(MusicVolume, FadeInTransitionDuration, _audioStreamPlayer);
+        private AudioStreamPlayer _audioStreamPlayer;
+        private SpectrumAnalyzer _spectrumAnalyzer;
+
+        private FadeOutAudio _fadeOutAudio;
+        private FadeInAudio _fadeInAudio;
+
+
+        // Called when the node enters the scene tree for the first time.
+        public override void _Ready()
+        {
+            _audioStreamPlayer = GetNode<AudioStreamPlayer>("Music_AudioStream");
+            _spectrumAnalyzer = GetNode<SpectrumAnalyzer>("/root/World/Spectrum_Analyzer");
+            _fadeOutAudio = GetNode<FadeOutAudio>("FadeOut_Tween");
+            _fadeInAudio = GetNode<FadeInAudio>("FadeIn_Tween");
+
+            _spectrumAnalyzer.SetAudioStreamPlayer(_audioStreamPlayer);
+        }
+
+        /*
+         * Play the audio stream player instantly
+         */
+        public void PlayAudioStreamPlayer()
+        {
+            _audioStreamPlayer.VolumeDb = MusicVolume;
+            _audioStreamPlayer.Play();
+        }
+
+        /*
+         * Stops the audio stream player instantly
+         */
+        public void StopAudioStreamPlayer()
+        {
+            _audioStreamPlayer.Stop();
+        }
+
+        /*
+         * Plays a fade out effect to the audio stream player
+         * with the given transition duration
+         */
+        public void FadeOutAudio()
+        {
+            _fadeOutAudio.FadeOut(FadeOutTransitionDuration, _audioStreamPlayer);
+        }
+
+        /*
+         * Plays a fade in effect to the audio stream player
+         * with the given transition duration
+         */
+        public void FadeInAudio()
+        {
+            _fadeInAudio.FadeIn(MusicVolume, FadeInTransitionDuration, _audioStreamPlayer);
+        }
     }
 }

--- a/Scripts/Audio/FadeInAudio.cs
+++ b/Scripts/Audio/FadeInAudio.cs
@@ -1,28 +1,31 @@
 using Godot;
 
-public class FadeInAudio : AudioEffect
+namespace Asteroids.Scripts
 {
-    
-    // Called when the node enters the scene tree for the first time.
-    public override void _Ready()
+    public class FadeInAudio : AudioEffect
     {
-        Connect("tween_started", this, "OnFadeInTweenCompleted");
-    }
-    
-    /*
-     * Uses a tween node to interpolate the volume property to
-     * the audio stream player to simulate the fade in effect
-     */
-    public void FadeIn(float maximumVolume, float transitionDuration, AudioStreamPlayer audioStreamPlayer)
-    {
-        InterpolateProperty(audioStreamPlayer, VolumeProperty, LowestVolume,
-                    maximumVolume, transitionDuration, TransitionType.Linear, EaseType.In);
-        Start();
-    }
 
-    private void OnFadeInTweenCompleted(Object @object, NodePath key)
-    {
-        var audioStreamPlayer = (AudioStreamPlayer)@object;
-        audioStreamPlayer.Play();
-    } 
+        // Called when the node enters the scene tree for the first time.
+        public override void _Ready()
+        {
+            Connect("tween_started", this, "OnFadeInTweenCompleted");
+        }
+
+        /*
+         * Uses a tween node to interpolate the volume property to
+         * the audio stream player to simulate the fade in effect
+         */
+        public void FadeIn(float maximumVolume, float transitionDuration, AudioStreamPlayer audioStreamPlayer)
+        {
+            InterpolateProperty(audioStreamPlayer, VolumeProperty, LowestVolume,
+                        maximumVolume, transitionDuration, TransitionType.Linear, EaseType.In);
+            Start();
+        }
+
+        private void OnFadeInTweenCompleted(Object @object, NodePath key)
+        {
+            var audioStreamPlayer = (AudioStreamPlayer)@object;
+            audioStreamPlayer.Play();
+        }
+    }
 }

--- a/Scripts/Audio/FadeInAudio.cs
+++ b/Scripts/Audio/FadeInAudio.cs
@@ -1,6 +1,6 @@
 using Godot;
 
-namespace Asteroids.Scripts
+namespace Asteroids
 {
     public class FadeInAudio : AudioEffect
     {

--- a/Scripts/Audio/FadeInAudio.cs
+++ b/Scripts/Audio/FadeInAudio.cs
@@ -1,5 +1,3 @@
-using Godot;
-
 namespace Asteroids
 {
     public class FadeInAudio : AudioEffect

--- a/Scripts/Audio/FadeOutAudio.cs
+++ b/Scripts/Audio/FadeOutAudio.cs
@@ -1,6 +1,6 @@
 using Godot;
 
-namespace Asteroids.Scripts
+namespace Asteroids
 {
     public class FadeOutAudio : AudioEffect
     {

--- a/Scripts/Audio/FadeOutAudio.cs
+++ b/Scripts/Audio/FadeOutAudio.cs
@@ -1,35 +1,38 @@
 using Godot;
 
-public class FadeOutAudio : AudioEffect
+namespace Asteroids.Scripts
 {
+    public class FadeOutAudio : AudioEffect
+    {
 
-    private float _lastVolume;
-    
-    // Called when the node enters the scene tree for the first time.
-    public override void _Ready()
-    {
-        Connect("tween_completed", this, "OnFadeOutTweenCompleted");
-    }
-    
-    /*
-    * Uses a tween node to interpolate the volume property to
-    * the audio stream player to simulate the fade out effect
-    */
-    public void FadeOut(float transitionDuration, AudioStreamPlayer audioStreamPlayer)
-    {
-        _lastVolume = audioStreamPlayer.VolumeDb;
-        InterpolateProperty(audioStreamPlayer, VolumeProperty, _lastVolume,
-                    LowestVolume, transitionDuration, Tween.TransitionType.Linear, EaseType.In);
-        Start();
-    }
+        private float _lastVolume;
 
-    /*
-     * Called when fade out tween completed signal is emitted
-     */
-    private void OnFadeOutTweenCompleted(Object @object, NodePath key)
-    {
-        var audioStreamPlayer = (AudioStreamPlayer) @object;
-        audioStreamPlayer.Stop();
-        audioStreamPlayer.VolumeDb = _lastVolume;
+        // Called when the node enters the scene tree for the first time.
+        public override void _Ready()
+        {
+            Connect("tween_completed", this, "OnFadeOutTweenCompleted");
+        }
+
+        /*
+        * Uses a tween node to interpolate the volume property to
+        * the audio stream player to simulate the fade out effect
+        */
+        public void FadeOut(float transitionDuration, AudioStreamPlayer audioStreamPlayer)
+        {
+            _lastVolume = audioStreamPlayer.VolumeDb;
+            InterpolateProperty(audioStreamPlayer, VolumeProperty, _lastVolume,
+                        LowestVolume, transitionDuration, Tween.TransitionType.Linear, EaseType.In);
+            Start();
+        }
+
+        /*
+         * Called when fade out tween completed signal is emitted
+         */
+        private void OnFadeOutTweenCompleted(Object @object, NodePath key)
+        {
+            var audioStreamPlayer = (AudioStreamPlayer)@object;
+            audioStreamPlayer.Stop();
+            audioStreamPlayer.VolumeDb = _lastVolume;
+        }
     }
 }

--- a/Scripts/Audio/FadeOutAudio.cs
+++ b/Scripts/Audio/FadeOutAudio.cs
@@ -1,5 +1,3 @@
-using Godot;
-
 namespace Asteroids
 {
     public class FadeOutAudio : AudioEffect

--- a/Scripts/Audio/SpectrumAnalyzer.cs
+++ b/Scripts/Audio/SpectrumAnalyzer.cs
@@ -1,7 +1,3 @@
-using System;
-using System.ComponentModel;
-using Godot;
-
 namespace Asteroids
 {
     public class SpectrumAnalyzer : Node2D

--- a/Scripts/Audio/SpectrumAnalyzer.cs
+++ b/Scripts/Audio/SpectrumAnalyzer.cs
@@ -2,131 +2,134 @@ using System;
 using System.ComponentModel;
 using Godot;
 
-public class SpectrumAnalyzer : Node2D
+namespace Asteroids.Scripts
 {
-    
-    private struct Range
+    public class SpectrumAnalyzer : Node2D
     {
-        public int Minimum { get; }
-        public int Maximum { get; }
 
-        public Range(int minimum, int maximum)
+        private struct Range
         {
-            Minimum = minimum;
-            Maximum = maximum;
+            public int Minimum { get; }
+            public int Maximum { get; }
+
+            public Range(int minimum, int maximum)
+            {
+                Minimum = minimum;
+                Maximum = maximum;
+            }
+
+            public int GetRangeDifference()
+            {
+                return Maximum - Minimum;
+            }
         }
 
-        public int GetRangeDifference()
-        {
-            return Maximum - Minimum;
-        }
-    }
+        private const int FrequencyAmount = 20;
 
-    private const int FrequencyAmount = 20;
-
-    /*
-     * Audible hertz range for humans
-     */
-    private const int MaximumFrequency = 20000;
-    private const int MinimumFrequency = 20;
-
-    /*
-     * Common music decibel range values
-     */
-    private const int MaximumDecibel = -20;
-    private const int MinimumDecibel = -50;
-    
-    private AudioEffectSpectrumAnalyzerInstance _audioSpectrum;
-    private Range _frequencyRange;
-    private Range _dbRange;
-    
-    public float[] FrequenciesLoudness { get; } = new float[FrequencyAmount]; // Loudness of each frequency
-    
-    public override void _Ready()
-    {
         /*
-         * Create the spectrum analyzer effect and add it to the master audio server
+         * Audible hertz range for humans
          */
-        var spectrumAnalyzerEffect = new AudioEffectSpectrumAnalyzer();
-        AudioServer.AddBusEffect(0, spectrumAnalyzerEffect);
-        
-        /*
-         * Retrieve the recent created audio spectrum effect as
-         * and instance to access all its properties
-         */
-        _audioSpectrum = (AudioEffectSpectrumAnalyzerInstance) AudioServer.GetBusEffectInstance(0, 0);
-        
-        _frequencyRange = new Range(MinimumFrequency, MaximumFrequency);
-    }
+        private const int MaximumFrequency = 20000;
+        private const int MinimumFrequency = 20;
 
-    public override void _Process(float delta)
-    {
-        float frequency = _frequencyRange.Minimum;
-        var interval = _frequencyRange.GetRangeDifference() / FrequencyAmount;
-        
-        for (uint i = 0; i < FrequencyAmount; i++)
+        /*
+         * Common music decibel range values
+         */
+        private const int MaximumDecibel = -20;
+        private const int MinimumDecibel = -50;
+
+        private AudioEffectSpectrumAnalyzerInstance _audioSpectrum;
+        private Range _frequencyRange;
+        private Range _dbRange;
+
+        public float[] FrequenciesLoudness { get; } = new float[FrequencyAmount]; // Loudness of each frequency
+
+        public override void _Ready()
         {
-            float previousFrequencyScale = GetFrequencyScale(frequency, _frequencyRange);
-            frequency += interval;
-            float frequencyScale = GetFrequencyScale(frequency, _frequencyRange);
-            
-            float frequencyRangeLow = GetFrequencyRange(previousFrequencyScale, _frequencyRange);
-            float frequencyRangeHigh = GetFrequencyRange(frequencyScale, _frequencyRange);
-            
-            float magnitude = GD.Linear2Db(_audioSpectrum.
-                GetMagnitudeForFrequencyRange(frequencyRangeLow, frequencyRangeHigh).Length());
-            
             /*
-             * Subtract the current magnitude to the minimum decibel and
-             * divide by the difference to get the current volume level
+             * Create the spectrum analyzer effect and add it to the master audio server
              */
-            magnitude = (magnitude - _dbRange.Minimum) / _dbRange.GetRangeDifference(); // Slope multiplication
-            magnitude += 0.3f * frequencyScale;
-            magnitude = Mathf.Clamp(magnitude, 0.05f, 1);
+            var spectrumAnalyzerEffect = new AudioEffectSpectrumAnalyzer();
+            AudioServer.AddBusEffect(0, spectrumAnalyzerEffect);
 
-            FrequenciesLoudness[i] = /*Mathf.Lerp(FrequenciesLoudness[i], magnitude, 20.0f * delta);*/ magnitude;
+            /*
+             * Retrieve the recent created audio spectrum effect as
+             * and instance to access all its properties
+             */
+            _audioSpectrum = (AudioEffectSpectrumAnalyzerInstance)AudioServer.GetBusEffectInstance(0, 0);
+
+            _frequencyRange = new Range(MinimumFrequency, MaximumFrequency);
         }
-    }
 
-    /*
-    * Must be called before using the analyzer. Creates the frequency
-     * and decibel range the spectrum analyzer is going to use.
-    */
-    public void SetAudioStreamPlayer(AudioStreamPlayer audioStreamPlayer)
-    {
-        float currentMusicVolume = audioStreamPlayer.VolumeDb;
-        _dbRange = new Range(MinimumDecibel + (int) currentMusicVolume, MaximumDecibel + (int) currentMusicVolume);
-    }
-    
-    /*
-     * Draw an audio visualizer of the current playing music.
-     */
-    private void DrawAudioVisualizer()
-    {
-        Vector2 drawPos = Vector2.Zero;
-        float interval = 200f / FrequencyAmount;
-    
-        for (uint i = 0; i < FrequencyAmount; i++)
+        public override void _Process(float delta)
         {
-            DrawLine(drawPos, drawPos + new Vector2(0, -FrequenciesLoudness[i] * 50), Colors.Chocolate, 4.0f, true);
-            drawPos.x += interval;
+            float frequency = _frequencyRange.Minimum;
+            var interval = _frequencyRange.GetRangeDifference() / FrequencyAmount;
+
+            for (uint i = 0; i < FrequencyAmount; i++)
+            {
+                float previousFrequencyScale = GetFrequencyScale(frequency, _frequencyRange);
+                frequency += interval;
+                float frequencyScale = GetFrequencyScale(frequency, _frequencyRange);
+
+                float frequencyRangeLow = GetFrequencyRange(previousFrequencyScale, _frequencyRange);
+                float frequencyRangeHigh = GetFrequencyRange(frequencyScale, _frequencyRange);
+
+                float magnitude = GD.Linear2Db(_audioSpectrum.
+                    GetMagnitudeForFrequencyRange(frequencyRangeLow, frequencyRangeHigh).Length());
+
+                /*
+                 * Subtract the current magnitude to the minimum decibel and
+                 * divide by the difference to get the current volume level
+                 */
+                magnitude = (magnitude - _dbRange.Minimum) / _dbRange.GetRangeDifference(); // Slope multiplication
+                magnitude += 0.3f * frequencyScale;
+                magnitude = Mathf.Clamp(magnitude, 0.05f, 1);
+
+                FrequenciesLoudness[i] = /*Mathf.Lerp(FrequenciesLoudness[i], magnitude, 20.0f * delta);*/ magnitude;
+            }
         }
-    }        
 
-    /*
-     * Returns the interpolated value between the maximum and minimum
-     * of the frequency range of four times the received frequency scale
-     */
-    private static float GetFrequencyRange(float frequencyScale, Range frequencyRange)
-    {
-        return Mathf.Lerp(frequencyRange.Minimum, frequencyRange.Maximum, Mathf.Pow(frequencyScale, 4));
-    }
+        /*
+        * Must be called before using the analyzer. Creates the frequency
+         * and decibel range the spectrum analyzer is going to use.
+        */
+        public void SetAudioStreamPlayer(AudioStreamPlayer audioStreamPlayer)
+        {
+            float currentMusicVolume = audioStreamPlayer.VolumeDb;
+            _dbRange = new Range(MinimumDecibel + (int)currentMusicVolume, MaximumDecibel + (int)currentMusicVolume);
+        }
 
-    /*
-     * Return the the scale of given frequency
-     */
-    private static float GetFrequencyScale(float frequency, Range frequencyRange)
-    {
-        return (frequency - frequencyRange.Minimum) / frequencyRange.GetRangeDifference();
+        /*
+         * Draw an audio visualizer of the current playing music.
+         */
+        private void DrawAudioVisualizer()
+        {
+            Vector2 drawPos = Vector2.Zero;
+            float interval = 200f / FrequencyAmount;
+
+            for (uint i = 0; i < FrequencyAmount; i++)
+            {
+                DrawLine(drawPos, drawPos + new Vector2(0, -FrequenciesLoudness[i] * 50), Colors.Chocolate, 4.0f, true);
+                drawPos.x += interval;
+            }
+        }
+
+        /*
+         * Returns the interpolated value between the maximum and minimum
+         * of the frequency range of four times the received frequency scale
+         */
+        private static float GetFrequencyRange(float frequencyScale, Range frequencyRange)
+        {
+            return Mathf.Lerp(frequencyRange.Minimum, frequencyRange.Maximum, Mathf.Pow(frequencyScale, 4));
+        }
+
+        /*
+         * Return the the scale of given frequency
+         */
+        private static float GetFrequencyScale(float frequency, Range frequencyRange)
+        {
+            return (frequency - frequencyRange.Minimum) / frequencyRange.GetRangeDifference();
+        }
     }
 }

--- a/Scripts/Audio/SpectrumAnalyzer.cs
+++ b/Scripts/Audio/SpectrumAnalyzer.cs
@@ -2,7 +2,7 @@ using System;
 using System.ComponentModel;
 using Godot;
 
-namespace Asteroids.Scripts
+namespace Asteroids
 {
     public class SpectrumAnalyzer : Node2D
     {

--- a/Scripts/Manager/ColorManager.cs
+++ b/Scripts/Manager/ColorManager.cs
@@ -1,6 +1,4 @@
 using System;
-using System.Linq;
-using Godot;
 
 namespace Asteroids.Manager
 {

--- a/Scripts/Manager/ColorManager.cs
+++ b/Scripts/Manager/ColorManager.cs
@@ -2,7 +2,7 @@ using System;
 using System.Linq;
 using Godot;
 
-namespace Asteroids.Scripts.Manager
+namespace Asteroids.Manager
 {
     public class ColorManager : Node2D
     {

--- a/Scripts/Manager/GameManager.cs
+++ b/Scripts/Manager/GameManager.cs
@@ -1,9 +1,9 @@
-using Asteroids.Scripts.Player.Controllers.Manager;
-using Asteroids.Scripts.Rock.Implementation;
+using Asteroids.Player.Controllers.Manager;
+using Asteroids.Rock.Implementation;
 using Godot;
 using Godot.Collections;
 
-namespace Asteroids.Scripts.Manager
+namespace Asteroids.Manager
 {
 	public class GameManager : Node
 	{

--- a/Scripts/Manager/GameManager.cs
+++ b/Scripts/Manager/GameManager.cs
@@ -15,9 +15,9 @@ namespace Asteroids.Manager
 		private const float RockRotation = Mathf.Pi / 4;
 		private const int ScorePerSecond = 1;
 
-		[Export] private PackedScene _mediumRockScene;
-		[Export] private PackedScene _bigRockScene;
-		[Export] private PackedScene _playerScene;
+		[Export] protected PackedScene _mediumRockScene;
+		[Export] protected PackedScene _bigRockScene;
+		[Export] protected PackedScene _playerScene;
 
 		private AudioManager _audioManager;
 		private UserInterface.UserInterface _userInterface;

--- a/Scripts/Manager/GameManager.cs
+++ b/Scripts/Manager/GameManager.cs
@@ -1,6 +1,9 @@
-using Asteroids.Player.Controllers.Manager;
-using Asteroids.Rock.Implementation;
-using Godot;
+global using Godot;
+global using Asteroids.Player.Controllers.Manager;
+global using Asteroids.Rock.Implementation;
+global using System.Linq;
+global using System.Collections.Generic;
+
 using Godot.Collections;
 
 namespace Asteroids.Manager

--- a/Scripts/Manager/GameStatus.cs
+++ b/Scripts/Manager/GameStatus.cs
@@ -1,4 +1,4 @@
-﻿namespace Asteroids.Scripts.Manager
+﻿namespace Asteroids.Manager
 {
     public enum GameStatus : uint
     {

--- a/Scripts/Player/Controllers/Animation/PlayerAnimation.cs
+++ b/Scripts/Player/Controllers/Animation/PlayerAnimation.cs
@@ -1,6 +1,4 @@
-﻿using Godot;
-
-namespace Asteroids.Player.Controllers.Animation
+﻿namespace Asteroids.Player.Controllers.Animation
 {
     public class PlayerAnimation : Node
     {

--- a/Scripts/Player/Controllers/Animation/PlayerAnimation.cs
+++ b/Scripts/Player/Controllers/Animation/PlayerAnimation.cs
@@ -1,6 +1,6 @@
 ﻿using Godot;
 
-namespace Asteroids.Scripts.Player.Controllers.Animation
+namespace Asteroids.Player.Controllers.Animation
 {
     public class PlayerAnimation : Node
     {

--- a/Scripts/Player/Controllers/Attack/Attack.cs
+++ b/Scripts/Player/Controllers/Attack/Attack.cs
@@ -2,8 +2,8 @@
 {
     public abstract class Attack : Node
     {
-        [Export] private float _bulletSpeed = 500.0f;
-        [Export] private PackedScene _bulletScene;
+        [Export] protected float _bulletSpeed = 500.0f;
+        [Export] protected PackedScene _bulletScene;
 
         protected Position2D BulletSpawnPosition { get; private set; }
         

--- a/Scripts/Player/Controllers/Attack/Attack.cs
+++ b/Scripts/Player/Controllers/Attack/Attack.cs
@@ -1,6 +1,6 @@
 ﻿using Godot;
 
-namespace Asteroids.Scripts.Player.Controllers.Attack
+namespace Asteroids.Player.Controllers.Attack
 {
     public abstract class Attack : Node
     {

--- a/Scripts/Player/Controllers/Attack/Attack.cs
+++ b/Scripts/Player/Controllers/Attack/Attack.cs
@@ -1,6 +1,4 @@
-﻿using Godot;
-
-namespace Asteroids.Player.Controllers.Attack
+﻿namespace Asteroids.Player.Controllers.Attack
 {
     public abstract class Attack : Node
     {

--- a/Scripts/Player/Controllers/Attack/PlayerAttack.cs
+++ b/Scripts/Player/Controllers/Attack/PlayerAttack.cs
@@ -1,7 +1,7 @@
 using System.Collections.Generic;
 using Godot;
 
-namespace Asteroids.Scripts.Player.Controllers.Attack
+namespace Asteroids.Player.Controllers.Attack
 {
     public class PlayerAttack : Attack
     {

--- a/Scripts/Player/Controllers/Attack/PlayerAttack.cs
+++ b/Scripts/Player/Controllers/Attack/PlayerAttack.cs
@@ -1,6 +1,3 @@
-using System.Collections.Generic;
-using Godot;
-
 namespace Asteroids.Player.Controllers.Attack
 {
     public class PlayerAttack : Attack

--- a/Scripts/Player/Controllers/Attack/PlayerSpecialAttack.cs
+++ b/Scripts/Player/Controllers/Attack/PlayerSpecialAttack.cs
@@ -2,7 +2,7 @@
 {
     public class PlayerSpecialAttack : Attack
     {
-        [Export] private int _numberSpecials = 3;
+        [Export] protected int _numberSpecials = 3;
         
         private Timer _specialTimer;
         

--- a/Scripts/Player/Controllers/Attack/PlayerSpecialAttack.cs
+++ b/Scripts/Player/Controllers/Attack/PlayerSpecialAttack.cs
@@ -1,7 +1,4 @@
-﻿using System.Collections.Generic;
-using Godot;
-
-namespace Asteroids.Player.Controllers.Attack
+﻿namespace Asteroids.Player.Controllers.Attack
 {
     public class PlayerSpecialAttack : Attack
     {

--- a/Scripts/Player/Controllers/Attack/PlayerSpecialAttack.cs
+++ b/Scripts/Player/Controllers/Attack/PlayerSpecialAttack.cs
@@ -1,7 +1,7 @@
 ﻿using System.Collections.Generic;
 using Godot;
 
-namespace Asteroids.Scripts.Player.Controllers.Attack
+namespace Asteroids.Player.Controllers.Attack
 {
     public class PlayerSpecialAttack : Attack
     {

--- a/Scripts/Player/Controllers/Input/PlayerInput.cs
+++ b/Scripts/Player/Controllers/Input/PlayerInput.cs
@@ -1,6 +1,6 @@
 using Godot;
 
-namespace Asteroids.Scripts.Player.Controllers.Input
+namespace Asteroids.Player.Controllers.Input
 {
     public class PlayerInput : Node
     {

--- a/Scripts/Player/Controllers/Input/PlayerInput.cs
+++ b/Scripts/Player/Controllers/Input/PlayerInput.cs
@@ -1,5 +1,3 @@
-using Godot;
-
 namespace Asteroids.Player.Controllers.Input
 {
     public class PlayerInput : Node

--- a/Scripts/Player/Controllers/Manager/PlayerManager.cs
+++ b/Scripts/Player/Controllers/Manager/PlayerManager.cs
@@ -2,7 +2,6 @@
 using Asteroids.Player.Controllers.Attack;
 using Asteroids.Player.Controllers.Input;
 using Asteroids.Player.Controllers.Movement;
-using Godot;
 
 namespace Asteroids.Player.Controllers.Manager
 {

--- a/Scripts/Player/Controllers/Manager/PlayerManager.cs
+++ b/Scripts/Player/Controllers/Manager/PlayerManager.cs
@@ -1,10 +1,10 @@
-﻿using Asteroids.Scripts.Player.Controllers.Animation;
-using Asteroids.Scripts.Player.Controllers.Attack;
-using Asteroids.Scripts.Player.Controllers.Input;
-using Asteroids.Scripts.Player.Controllers.Movement;
+﻿using Asteroids.Player.Controllers.Animation;
+using Asteroids.Player.Controllers.Attack;
+using Asteroids.Player.Controllers.Input;
+using Asteroids.Player.Controllers.Movement;
 using Godot;
 
-namespace Asteroids.Scripts.Player.Controllers.Manager
+namespace Asteroids.Player.Controllers.Manager
 {
     public class PlayerManager : Area2D
     {

--- a/Scripts/Player/Controllers/Movement/PlayerMovement.cs
+++ b/Scripts/Player/Controllers/Movement/PlayerMovement.cs
@@ -1,6 +1,6 @@
 using Godot;
 
-namespace Asteroids.Scripts.Player.Controllers.Movement
+namespace Asteroids.Player.Controllers.Movement
 {
     public class PlayerMovement : Node
     {

--- a/Scripts/Player/Controllers/Movement/PlayerMovement.cs
+++ b/Scripts/Player/Controllers/Movement/PlayerMovement.cs
@@ -1,5 +1,3 @@
-using Godot;
-
 namespace Asteroids.Player.Controllers.Movement
 {
     public class PlayerMovement : Node

--- a/Scripts/Player/Controllers/Movement/PlayerMovement.cs
+++ b/Scripts/Player/Controllers/Movement/PlayerMovement.cs
@@ -2,7 +2,7 @@ namespace Asteroids.Player.Controllers.Movement
 {
     public class PlayerMovement : Node
     {
-        [Export] private float _speed = 500;
+        [Export] protected float _speed = 500;
     
         private const float Acceleration = 0.2f;
         private const float Friction = 0.02f;

--- a/Scripts/Player/Controllers/Movement/PlayerRotation.cs
+++ b/Scripts/Player/Controllers/Movement/PlayerRotation.cs
@@ -1,5 +1,3 @@
-using Godot;
-
 namespace Asteroids.Player.Controllers.Movement
 {
     public class PlayerRotation : Node

--- a/Scripts/Player/Controllers/Movement/PlayerRotation.cs
+++ b/Scripts/Player/Controllers/Movement/PlayerRotation.cs
@@ -1,6 +1,6 @@
 using Godot;
 
-namespace Asteroids.Scripts.Player.Controllers.Movement
+namespace Asteroids.Player.Controllers.Movement
 {
     public class PlayerRotation : Node
     {

--- a/Scripts/Player/Instances/Bullet.cs
+++ b/Scripts/Player/Instances/Bullet.cs
@@ -1,4 +1,4 @@
-using Asteroids.Scripts.Rock.Interface;
+using Asteroids.Rock.Interface;
 using Godot;
 
 namespace Asteroids
@@ -22,7 +22,7 @@ namespace Asteroids
          */
         private void OnBulletBodyEntered(Node body)
         {
-            if (!(body is Rock rock)) return;
+            if (!(body is Asteroids.Rock.Interface.Rock rock)) return;
 
             rock.DestroyRock();
             QueueFree();

--- a/Scripts/Player/Instances/Bullet.cs
+++ b/Scripts/Player/Instances/Bullet.cs
@@ -1,6 +1,3 @@
-using Asteroids.Rock.Interface;
-using Godot;
-
 namespace Asteroids
 {
     public class Bullet : RigidBody2D

--- a/Scripts/Player/Instances/Bullet.cs
+++ b/Scripts/Player/Instances/Bullet.cs
@@ -1,36 +1,39 @@
 using Asteroids.Scripts.Rock.Interface;
 using Godot;
 
-public class Bullet : RigidBody2D
+namespace Asteroids
 {
+    public class Bullet : RigidBody2D
+    {
 
-    private VisibilityNotifier2D _visibilityNotifier;
-    
-    // Called when the node enters the scene tree for the first time.
-    public override void _Ready()
-    {
-        _visibilityNotifier = GetNode<VisibilityNotifier2D>("VisibilityNotifier");
-        _visibilityNotifier.Connect("screen_exited", this, "OnScreenExited");
-        
-        Connect("body_entered", this, "OnBulletBodyEntered");
-    }
+        private VisibilityNotifier2D _visibilityNotifier;
 
-    /*
-     * Called on body entered signal from the rigidbody node
-     */
-    private void OnBulletBodyEntered(Node body)
-    {
-        if (!(body is Rock rock)) return;
-        
-        rock.DestroyRock();
-        QueueFree();
-    }
-    
-    /*
-     * Called on screen exited from visibility notifier node
-     */
-    private void OnScreenExited()
-    {
-        QueueFree();
+        // Called when the node enters the scene tree for the first time.
+        public override void _Ready()
+        {
+            _visibilityNotifier = GetNode<VisibilityNotifier2D>("VisibilityNotifier");
+            _visibilityNotifier.Connect("screen_exited", this, "OnScreenExited");
+
+            Connect("body_entered", this, "OnBulletBodyEntered");
+        }
+
+        /*
+         * Called on body entered signal from the rigidbody node
+         */
+        private void OnBulletBodyEntered(Node body)
+        {
+            if (!(body is Rock rock)) return;
+
+            rock.DestroyRock();
+            QueueFree();
+        }
+
+        /*
+         * Called on screen exited from visibility notifier node
+         */
+        private void OnScreenExited()
+        {
+            QueueFree();
+        }
     }
 }

--- a/Scripts/Rock/Explosion/Explosion.cs
+++ b/Scripts/Rock/Explosion/Explosion.cs
@@ -1,6 +1,3 @@
-using Godot;
-using System;
-
 namespace Asteroids
 {
     public class Explosion : Node2D

--- a/Scripts/Rock/Explosion/Explosion.cs
+++ b/Scripts/Rock/Explosion/Explosion.cs
@@ -1,42 +1,45 @@
 using Godot;
 using System;
 
-public class Explosion : Node2D
+namespace Asteroids
 {
-
-    private const float TimerOffset = 0.5f;
-    
-    private CPUParticles2D _explosionParticles;
-    private AudioStreamPlayer _explosionStreamPlayer;
-    private Timer _queueFreeTimer;
-    
-    // Called when the node enters the scene tree for the first time.
-    public override void _Ready()
+    public class Explosion : Node2D
     {
-        _explosionParticles = GetNode<CPUParticles2D>("CPUParticles2D");
-        _explosionStreamPlayer = GetNode<AudioStreamPlayer>("Explosion_AudioStream");
-        _queueFreeTimer = GetNode<Timer>("QueueFree_Timer");
 
-        _explosionParticles.Emitting = true;
-        _queueFreeTimer.WaitTime = _explosionParticles.Lifetime + TimerOffset;
-        _queueFreeTimer.Connect("timeout", this, "OnQueueFreeTimerTimeout");
-    }
+        private const float TimerOffset = 0.5f;
 
-    /*
-     * Emits the explosion audio and particle effect
-     */
-    public void EmitsExplosion(Vector2 position)
-    {
-        GlobalPosition = position;
-        _explosionStreamPlayer.Play();
-        _queueFreeTimer.Start();
-    }
-    
-    /*
-     * Called on queue free timer timeout signal
-     */
-    private void OnQueueFreeTimerTimeout()
-    {
-        QueueFree();
+        private CPUParticles2D _explosionParticles;
+        private AudioStreamPlayer _explosionStreamPlayer;
+        private Timer _queueFreeTimer;
+
+        // Called when the node enters the scene tree for the first time.
+        public override void _Ready()
+        {
+            _explosionParticles = GetNode<CPUParticles2D>("CPUParticles2D");
+            _explosionStreamPlayer = GetNode<AudioStreamPlayer>("Explosion_AudioStream");
+            _queueFreeTimer = GetNode<Timer>("QueueFree_Timer");
+
+            _explosionParticles.Emitting = true;
+            _queueFreeTimer.WaitTime = _explosionParticles.Lifetime + TimerOffset;
+            _queueFreeTimer.Connect("timeout", this, "OnQueueFreeTimerTimeout");
+        }
+
+        /*
+         * Emits the explosion audio and particle effect
+         */
+        public void EmitsExplosion(Vector2 position)
+        {
+            GlobalPosition = position;
+            _explosionStreamPlayer.Play();
+            _queueFreeTimer.Start();
+        }
+
+        /*
+         * Called on queue free timer timeout signal
+         */
+        private void OnQueueFreeTimerTimeout()
+        {
+            QueueFree();
+        }
     }
 }

--- a/Scripts/Rock/Implementation/BigRock.cs
+++ b/Scripts/Rock/Implementation/BigRock.cs
@@ -1,5 +1,3 @@
-using Godot;
-
 namespace Asteroids.Rock.Implementation
 {
     public class BigRock : Interface.Rock

--- a/Scripts/Rock/Implementation/BigRock.cs
+++ b/Scripts/Rock/Implementation/BigRock.cs
@@ -6,8 +6,8 @@ namespace Asteroids.Rock.Implementation
         [Export] public override int MaxSpeed { get; set; } = 320;
         [Export] public override int DestroyedScore { get; set; } = 10;
         
-        [Export] private PackedScene _mediumRockScene;
-        [Export] private int _amountMediumRocks = 3;
+        [Export] protected PackedScene _mediumRockScene;
+        [Export] protected int _amountMediumRocks = 3;
 
         /*
         * Create a certain amount of medium rocks with random impulse when

--- a/Scripts/Rock/Implementation/BigRock.cs
+++ b/Scripts/Rock/Implementation/BigRock.cs
@@ -1,6 +1,6 @@
 using Godot;
 
-namespace Asteroids.Scripts.Rock.Implementation
+namespace Asteroids.Rock.Implementation
 {
     public class BigRock : Interface.Rock
     {
@@ -19,7 +19,7 @@ namespace Asteroids.Scripts.Rock.Implementation
         {
             for (uint i = 0; i < _amountMediumRocks; i++)
             {
-                if(!(_mediumRockScene?.Instance() is global::Asteroids.Scripts.Rock.Implementation.MediumRock smallRockInstance)) return;
+                if(!(_mediumRockScene?.Instance() is global::Asteroids.Rock.Implementation.MediumRock smallRockInstance)) return;
                 GetTree().Root.CallDeferred("add_child", smallRockInstance); // Delay the AddChild method until engine is ready to execute it
             
                 double rockRotation = GD.RandRange(-Mathf.Pi, Mathf.Pi);

--- a/Scripts/Rock/Implementation/MediumRock.cs
+++ b/Scripts/Rock/Implementation/MediumRock.cs
@@ -1,6 +1,6 @@
 using Godot;
 
-namespace Asteroids.Scripts.Rock.Implementation
+namespace Asteroids.Rock.Implementation
 {
 	public class MediumRock : Interface.Rock
 	{

--- a/Scripts/Rock/Implementation/MediumRock.cs
+++ b/Scripts/Rock/Implementation/MediumRock.cs
@@ -1,5 +1,3 @@
-using Godot;
-
 namespace Asteroids.Rock.Implementation
 {
 	public class MediumRock : Interface.Rock

--- a/Scripts/Rock/Interface/Rock.cs
+++ b/Scripts/Rock/Interface/Rock.cs
@@ -1,6 +1,5 @@
 ﻿using System;
 using Asteroids.Manager;
-using Godot;
 
 namespace Asteroids.Rock.Interface
 {

--- a/Scripts/Rock/Interface/Rock.cs
+++ b/Scripts/Rock/Interface/Rock.cs
@@ -5,7 +5,7 @@ namespace Asteroids.Rock.Interface
 {
     public abstract class Rock : RigidBody2D
     {
-        [Export] private PackedScene _explosionScene;
+        [Export] protected PackedScene _explosionScene;
 
         private VisibilityNotifier2D _visibilityNotifier;
         private GameManager _gameManager;

--- a/Scripts/Rock/Interface/Rock.cs
+++ b/Scripts/Rock/Interface/Rock.cs
@@ -1,8 +1,8 @@
 ﻿using System;
-using Asteroids.Scripts.Manager;
+using Asteroids.Manager;
 using Godot;
 
-namespace Asteroids.Scripts.Rock.Interface
+namespace Asteroids.Rock.Interface
 {
     public abstract class Rock : RigidBody2D
     {

--- a/Scripts/UserInterface/UserInterface.cs
+++ b/Scripts/UserInterface/UserInterface.cs
@@ -1,6 +1,6 @@
 using Godot;
 
-namespace Asteroids.Scripts.UserInterface
+namespace Asteroids.UserInterface
 {
     public class UserInterface : CanvasLayer
     {

--- a/Scripts/UserInterface/UserInterface.cs
+++ b/Scripts/UserInterface/UserInterface.cs
@@ -1,5 +1,3 @@
-using Godot;
-
 namespace Asteroids.UserInterface
 {
     public class UserInterface : CanvasLayer

--- a/Scripts/UserInterface/WaveLabel.cs
+++ b/Scripts/UserInterface/WaveLabel.cs
@@ -1,7 +1,7 @@
 using System.Net;
 using Godot;
 
-namespace Asteroids.Scripts.UserInterface
+namespace Asteroids.UserInterface
 {
     public class WaveLabel : CanvasLayer
     {

--- a/Scripts/UserInterface/WaveLabel.cs
+++ b/Scripts/UserInterface/WaveLabel.cs
@@ -1,6 +1,3 @@
-using System.Net;
-using Godot;
-
 namespace Asteroids.UserInterface
 {
     public class WaveLabel : CanvasLayer


### PR DESCRIPTION
This PR does the following
- Adds namespaces to scripts that were missing them
- Removes ".Script" keyword from all namespace definitions as seemed very redundant
- Make use of global using from C#10
- Remove unused usings
- Change all exports from private to protected to suppress annoying warnings from VSCode